### PR TITLE
formatting for tags test

### DIFF
--- a/conda_oci_mirror/tests/test_pushpull_cache.py
+++ b/conda_oci_mirror/tests/test_pushpull_cache.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 import pytest
-from conftest import delete_tags  # noqa
 
 # The setup.cfg doesn't install the main module proper
 here = os.path.dirname(os.path.abspath(__file__))

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     click
     build
     requests 
-    oras==0.1.14
+    oras==0.1.16
     conda_package_handling @ git+https://github.com/conda/conda-package-handling.git#egg=main
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This should do linting tweaks so the PR linting passes - and I noticed that deleting tags wasn't used, so I deleted it! But if you want to use / add back, we can do:

```python
def delete_tags(registry, channel, subdir, name):
    """
    Delete all tags for a repo
    """
    target = f"{registry_url()}/{test_user()}/{channel}/{subdir}/{name}"
    try:
        tags = oras.get_tags(target)
        print(f"Got tags to delete {tags}")
    except Exception:
        return
    deleted = oras.delete_tags(target, tags)
    # deleted should be == to tags
```
Signed-off-by: vsoch <vsoch@users.noreply.github.com>